### PR TITLE
Add dapr docs with Java-SDK examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is the Dapr SDK for Java, including the following features:
 
 #### Pre-Requisites
 * JDK 11 or above - the published jars are compatible with Java 8:
+    * [AdoptOpenJDK 11 - LTS](https://adoptopenjdk.net/)
     * [Oracle's JDK 15](https://www.oracle.com/java/technologies/javase-jdk15-downloads.html)
     * [Oracle's JDK 11 - LTS](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
     * [OpenJDK](https://openjdk.java.net/)
@@ -50,19 +51,19 @@ For a Maven project, add the following to your `pom.xml` file:
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <!-- Dapr's SDK for Actors (optional). -->
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-actors</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <!-- Dapr's SDK integration with SpringBoot (optional). -->
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-springboot</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     ...
   </dependencies>
@@ -76,11 +77,11 @@ For a Gradle project, add the following to your `build.gradle` file:
 dependencies {
 ...
     // Dapr's core SDK with all features, except Actors.
-    compile('io.dapr:dapr-sdk:1.1.0')
+    compile('io.dapr:dapr-sdk:1.2.0')
     // Dapr's SDK for Actors (optional).
-    compile('io.dapr:dapr-sdk-actors:1.1.0')
+    compile('io.dapr:dapr-sdk-actors:1.2.0')
     // Dapr's SDK integration with SpringBoot (optional).
-    compile('io.dapr:dapr-sdk-springboot:1.1.0')
+    compile('io.dapr:dapr-sdk-springboot:1.2.0')
 }
 ```
 

--- a/daprdocs/README.md
+++ b/daprdocs/README.md
@@ -1,0 +1,25 @@
+# Dapr Java SDK documentation
+
+This page covers how the documentation is structured for the Dapr Java SDK
+
+## Dapr Docs
+
+All Dapr documentation is hosted at [docs.dapr.io](https://docs.dapr.io), including the docs for the [Java SDK](https://docs.dapr.io/developing-applications/sdks/java/). Head over there if you want to read the docs.
+
+### Java SDK docs source 
+
+Although the docs site code and content is in the [docs repo](https://github.com/dapr/docs), the Java SDK content and images are within the `content` and `static` directories, respectively. 
+
+This allows separation of roles and expertise between maintainers, and makes it easy to find the docs files you are looking for.
+
+## Writing Java SDK docs
+
+To get up and running to write Java SDK docs, visit the [docs repo](https://github.com/dapr/docs) to initialize your environment. It will clone both the docs repo and this repo, so you can make changes and see it rendered within the site instantly, as well as commit and PR into this repo.
+
+Make sure to read the [docs contributing guide](https://docs.dapr.io/contributing/contributing-docs/) for information on style/semantics/etc.
+
+## Docs architecture
+
+The docs site is built on [Hugo](https://gohugo.io), which lives in the docs repo. This repo is setup as a git submodule so that when the repo is cloned and initialized, the java-sdk repo, along with the docs, are cloned as well.
+
+Then, in the Hugo configuration file, the `daprdocs/content` and `daprdocs/static` directories are redirected to the `daprdocs/developing-applications/sdks/java` and `static/java` directories, respectively. Thus, all the content within this repo is folded into the main docs site.

--- a/daprdocs/content/en/java-sdk-contributing/java-contributing.md
+++ b/daprdocs/content/en/java-sdk-contributing/java-contributing.md
@@ -1,0 +1,23 @@
+---
+type: docs
+title: "Contributing to the Java SDK"
+linkTitle: "Java SDK"
+weight: 3000
+description: Guidelines for contributing to the Dapr Java SDK
+---
+
+When contributing to the [Java SDK](https://github.com/dapr/java-sdk) the following rules and best-practices should be followed.
+
+## Examples
+
+The `examples` directory contains code samples for users to run to try out specific functionality of the various Java SDK packages and extensions. When writing new and updated samples keep in mind:
+
+- All examples should be runnable on Windows, Linux, and MacOS. While Java code is consistent among operating systems, any pre/post example commands should provide options through [codetabs]({{< ref "contributing-docs.md#tabbed-content" >}})
+- Contain steps to download/install any required pre-requisites. Someone coming in with a fresh OS install should be able to start on the example and complete it without an error. Links to external download pages are fine.
+
+## Docs
+
+The `daprdocs` directory contains the markdown files that are rendered into the [Dapr Docs](https://docs.dapr.io) website. When the documentation website is built this repo is cloned and configured so that its contents are rendered with the docs content. When writing docs keep in mind:
+
+   - All rules in the [docs guide]({{< ref contributing-docs.md >}}) should be followed in addition to these.
+   - All files and directories should be prefixed with `java-` to ensure all file/directory names are globally unique across all Dapr documentation.

--- a/daprdocs/content/en/java-sdk-docs/_index.md
+++ b/daprdocs/content/en/java-sdk-docs/_index.md
@@ -1,0 +1,130 @@
+---
+type: docs
+title: "Dapr Java SDK"
+linkTitle: "Java"
+weight: 1000
+description: Java SDK packages for developing Dapr applications
+---
+
+## Pre-requisites
+
+- [Dapr CLI]({{< ref install-dapr-cli.md >}}) installed
+- Initialized [Dapr environment]({{< ref install-dapr-selfhost.md >}})
+- JDK 11 or above - the published jars are compatible with Java 8:
+    - [Oracle's JDK 15](https://www.oracle.com/java/technologies/javase-downloads.html)
+    - [Oracle's JDK 11 - LTS](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
+    - [OpenJDK](https://openjdk.java.net/)
+- Install one of the following build tools for Java:
+    - [Maven 3.x](https://maven.apache.org/install.html)
+    - [Gradle 6.x](https://gradle.org/install/)
+
+## Importing Dapr's Java SDK
+
+For a Maven project, add the following to your `pom.xml` file: 
+```java
+<project>
+  ...
+  <dependencies>
+    ...
+     // Dapr's core SDK with all features, except Actors. 
+    <dependency>
+      <groupId>io.dapr</groupId>
+      <artifactId>dapr-sdk</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    // Dapr's SDK for Actors (optional).
+    <dependency>
+      <groupId>io.dapr</groupId>
+      <artifactId>dapr-sdk-actors</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    // Dapr's SDK integration with SpringBoot (optional).
+    <dependency>
+      <groupId>io.dapr</groupId>
+      <artifactId>dapr-sdk-springboot</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    ...
+  </dependencies>
+  ...
+</project>
+```
+
+For a Gradle project, add the following to your `build.gradle` file:
+```java
+dependencies {
+...
+    // Dapr's core SDK with all features, except Actors.
+    compile('io.dapr:dapr-sdk:1.1.0')
+    // Dapr's SDK for Actors (optional).
+    compile('io.dapr:dapr-sdk-actors:1.1.0')
+    // Dapr's SDK integration with SpringBoot (optional).
+    compile('io.dapr:dapr-sdk-springboot:1.1.0')
+}
+```
+
+## Building blocks
+
+The Java SDK allows you to interface with all of the [Dapr building blocks]({{< ref building-blocks >}}).
+
+### Invoke a service
+
+```java
+// Java Example here
+```
+
+- For a full guide on service invocation visit [How-To: Invoke a service]({{< ref howto-invoke-discover-services.md >}}).
+- Visit [Java SDK examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/invoke) for code samples and instructions to try out service invocation
+
+### Save & get application state
+
+```java
+// Java Example here
+```
+
+- For a full list of state operations visit [How-To: Get & save state]({{< ref howto-get-save-state.md >}}).
+- Visit [Java SDK examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/state) for code samples and instructions to try out state management
+
+### Publish & subscribe to messages
+
+##### Publish messages
+
+```java
+// Java Example here
+```
+
+##### Subscribe to messages
+
+```java
+// Java Example here
+```
+
+- For a full list of state operations visit [How-To: Publish & subscribe]({{< ref howto-publish-subscribe.md >}}).
+- Visit [Java SDK examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/pubsub/http) for code samples and instructions to try out pub/sub
+
+### Interact with output bindings
+
+```java
+// Java Example here
+```
+
+- For a full guide on output bindings visit [How-To: Use bindings]({{< ref howto-bindings.md >}}).
+- Visit [Java SDK examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/bindings/http) for code samples and instructions to try out output bindings
+
+### Retrieve secrets
+
+```java
+// Java Example here
+```
+
+- For a full guide on secrets visit [How-To: Retrieve secrets]({{< ref howto-secrets.md >}}).
+- Visit [Java SDK examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/secrets) for code samples and instructions to try out retrieving secrets
+
+### Actors
+
+```java
+// Java Example here
+```
+
+## Related links
+- [Java SDK examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples)

--- a/daprdocs/content/en/java-sdk-docs/_index.md
+++ b/daprdocs/content/en/java-sdk-docs/_index.md
@@ -31,19 +31,19 @@ For a Maven project, add the following to your `pom.xml` file:
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     // Dapr's SDK for Actors (optional).
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-actors</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     // Dapr's SDK integration with SpringBoot (optional).
     <dependency>
       <groupId>io.dapr</groupId>
       <artifactId>dapr-sdk-springboot</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     ...
   </dependencies>
@@ -56,11 +56,11 @@ For a Gradle project, add the following to your `build.gradle` file:
 dependencies {
 ...
     // Dapr's core SDK with all features, except Actors.
-    compile('io.dapr:dapr-sdk:1.1.0')
+    compile('io.dapr:dapr-sdk:1.2.0')
     // Dapr's SDK for Actors (optional).
-    compile('io.dapr:dapr-sdk-actors:1.1.0')
+    compile('io.dapr:dapr-sdk-actors:1.2.0')
     // Dapr's SDK integration with SpringBoot (optional).
-    compile('io.dapr:dapr-sdk-springboot:1.1.0')
+    compile('io.dapr:dapr-sdk-springboot:1.2.0')
 }
 ```
 
@@ -127,11 +127,13 @@ import io.dapr.client.domain.Metadata;
 import static java.util.Collections.singletonMap;
 
 try (DaprClient client = (new DaprClientBuilder()).build()) {
-  client.publishEvent(PUBSUB_NAME,TOPIC_NAME,message,singletonMap(Metadata.TTL_IN_SECONDS, MESSAGE_TTL_IN_SECONDS)).block();
+  client.publishEvent(PUBSUB_NAME, TOPIC_NAME, message, singletonMap(Metadata.TTL_IN_SECONDS, MESSAGE_TTL_IN_SECONDS)).block();
 }
 ```
 
 ##### Subscribe to messages
+
+```java
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dapr.Topic;
 import io.dapr.client.domain.CloudEvent;
@@ -140,7 +142,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-```java
 @RestController
 public class SubscriberController {
 
@@ -172,7 +173,7 @@ import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
 
 try (DaprClient client = (new DaprClientBuilder()).build()) {
-  // sending a class with message
+  // sending a class with message; BINDING_OPERATION="create"
   client.invokeBinding(BINDING_NAME, BINDING_OPERATION, myClass).block();
 
   // sending a plain string


### PR DESCRIPTION
# Description

Updated the _index.md page with Java code examples and updated guidance for the JDK.  The code is at parity with Python and other SDK pages.  Examples work for: HTTP, gRPC, without serialization, and with serialization of data objects.  

## Issue reference

Partially fixes #579

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
